### PR TITLE
Implement live holdings and derivatives monitoring

### DIFF
--- a/derivatives.py
+++ b/derivatives.py
@@ -1,1 +1,163 @@
-# derivatives.py - 衍生品数据 (Binance/Bybit/OKX)
+"""Fetch derivatives metrics from major exchanges.
+
+The public REST APIs of Binance, Bybit and OKX are queried to obtain
+perpetual swap funding rates, a simple ``basis`` (mark price minus spot price)
+and open interest.  Results from all three venues are aggregated such that
+
+* funding – average of the three exchanges
+* basis   – average mark/spot difference
+* oi      – sum of open interest
+
+The module exposes :func:`fetch_all` which performs the aggregation for a
+single symbol like ``"BTCUSDT"`` or ``"ETHUSDT"``.  Each call returns a
+dictionary with the aggregated metrics which can be appended to a history
+store by :func:`append_history`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import httpx
+
+
+async def _binance(symbol: str) -> Tuple[float, float, float]:
+    """Return ``(funding, basis, oi)`` from Binance futures."""
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            prem = await client.get(
+                "https://fapi.binance.com/fapi/v1/premiumIndex",
+                params={"symbol": symbol},
+            )
+            prem.raise_for_status()
+            p = prem.json()
+            funding = float(p.get("lastFundingRate", 0))
+            mark = float(p.get("markPrice", 0))
+            spot = float(p.get("indexPrice", 0))
+
+            oi_resp = await client.get(
+                "https://fapi.binance.com/fapi/v1/openInterest",
+                params={"symbol": symbol},
+            )
+            oi_resp.raise_for_status()
+            oi = float(oi_resp.json().get("openInterest", 0))
+
+            return funding, mark - spot, oi
+    except Exception:
+        return 0.0, 0.0, 0.0
+
+
+async def _bybit(symbol: str) -> Tuple[float, float, float]:
+    """Return ``(funding, basis, oi)`` from Bybit linear swaps."""
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            ticker = await client.get(
+                "https://api.bybit.com/v5/market/tickers",
+                params={"category": "linear", "symbol": symbol},
+            )
+            ticker.raise_for_status()
+            t = ticker.json()["result"]["list"][0]
+            mark = float(t.get("markPrice", 0))
+            spot = float(t.get("indexPrice", 0))
+
+            funding_resp = await client.get(
+                "https://api.bybit.com/v5/market/funding/history",
+                params={"symbol": symbol, "limit": 1},
+            )
+            funding_resp.raise_for_status()
+            f = funding_resp.json()["result"]["list"][0]
+            funding = float(f.get("fundingRate", 0))
+
+            oi_resp = await client.get(
+                "https://api.bybit.com/v5/market/open-interest",
+                params={"category": "linear", "symbol": symbol, "interval": "5min"},
+            )
+            oi_resp.raise_for_status()
+            oi_list = oi_resp.json()["result"]["list"]
+            oi = float(oi_list[-1]["openInterest"]) if oi_list else 0.0
+
+            return funding, mark - spot, oi
+    except Exception:
+        return 0.0, 0.0, 0.0
+
+
+async def _okx(symbol: str) -> Tuple[float, float, float]:
+    """Return ``(funding, basis, oi)`` from OKX swaps."""
+
+    inst = symbol.replace("USDT", "-USDT")
+    swap = f"{inst}-SWAP"
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            spot_t = await client.get(
+                "https://www.okx.com/api/v5/market/ticker",
+                params={"instId": inst},
+            )
+            swap_t = await client.get(
+                "https://www.okx.com/api/v5/market/ticker",
+                params={"instId": swap},
+            )
+            fr = await client.get(
+                "https://www.okx.com/api/v5/public/funding-rate",
+                params={"instId": swap},
+            )
+            oi_resp = await client.get(
+                "https://www.okx.com/api/v5/public/open-interest",
+                params={"instId": swap},
+            )
+
+            for r in (spot_t, swap_t, fr, oi_resp):
+                r.raise_for_status()
+
+            spot = float(spot_t.json()["data"][0]["last"])
+            mark = float(swap_t.json()["data"][0]["last"])
+            funding = float(fr.json()["data"][0]["fundingRate"])
+            oi = float(oi_resp.json()["data"][0]["oi"])
+
+            return funding, mark - spot, oi
+    except Exception:
+        return 0.0, 0.0, 0.0
+
+
+async def fetch_all(symbol: str) -> Dict[str, float]:
+    """Aggregate derivatives metrics for ``symbol`` across all exchanges."""
+
+    results = await asyncio.gather(_binance(symbol), _bybit(symbol), _okx(symbol))
+
+    fundings = [r[0] for r in results if r]
+    bases = [r[1] for r in results if r]
+    oi_total = sum(r[2] for r in results if r)
+
+    return {
+        "symbol": symbol,
+        "funding": sum(fundings) / len(fundings) if fundings else 0.0,
+        "basis": sum(bases) / len(bases) if bases else 0.0,
+        "oi": oi_total,
+    }
+
+
+def append_history(symbol: str, data: Dict[str, Any], base: Path | None = None) -> None:
+    """Append ``data`` to a derivatives history file for ``symbol``."""
+
+    base = base or Path("data")
+    path = base / f"derivs_{symbol}.json"
+
+    try:
+        hist = json.loads(path.read_text())
+    except Exception:
+        hist = {"funding": [], "basis": [], "oi": [], "timestamps": []}
+
+    hist["funding"].append(data["funding"])
+    hist["basis"].append(data["basis"])
+    hist["oi"].append(data["oi"])
+    hist["timestamps"].append(data.get("time") or time.strftime("%H:%M", time.gmtime()))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(hist))
+

--- a/holdings.py
+++ b/holdings.py
@@ -1,1 +1,183 @@
-# holdings.py - 链上余额聚合逻辑 (Etherscan + Blockstream)
+"""Utility functions for fetching on‑chain holdings.
+
+This module talks to public blockchain APIs and aggregates balances for
+addresses listed in ``settings.json``.  Only a very small subset of the
+Etherscan and Blockstream APIs are used which keeps the implementation
+lightweight and dependency free beyond :mod:`httpx`.
+
+The main entry point is :func:`refresh_holdings` which reads the settings,
+fetches balances for all configured wallets and appends the resulting
+snapshot to ``data/holdings_history.json``.
+
+The code is written with network failures in mind – every API call is wrapped
+in ``try/except`` blocks and returns ``0`` on error so the rest of the
+pipeline can continue to operate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import httpx
+
+ETH_DECIMALS = 10**18
+TOKEN_DECIMALS = 10**6  # USDT/USDC on Ethereum use 6 decimals
+
+
+async def _eth_balance(client: httpx.AsyncClient, api_base: str, api_key: str, address: str) -> float:
+    """Return ETH balance for ``address`` in whole ETH."""
+
+    try:
+        resp = await client.get(
+            api_base,
+            params={
+                "module": "account",
+                "action": "balance",
+                "address": address,
+                "tag": "latest",
+                "apikey": api_key,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return float(data.get("result", 0)) / ETH_DECIMALS
+    except Exception:
+        return 0.0
+
+
+async def _token_balance(
+    client: httpx.AsyncClient,
+    api_base: str,
+    api_key: str,
+    contract: str,
+    address: str,
+) -> float:
+    """Return ERC20 token balance for ``address``.
+
+    The result is normalised using :data:`TOKEN_DECIMALS` which is suitable for
+    USDT/USDC tokens.
+    """
+
+    try:
+        resp = await client.get(
+            api_base,
+            params={
+                "module": "account",
+                "action": "tokenbalance",
+                "contractaddress": contract,
+                "address": address,
+                "tag": "latest",
+                "apikey": api_key,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return float(data.get("result", 0)) / TOKEN_DECIMALS
+    except Exception:
+        return 0.0
+
+
+async def _btc_balance(client: httpx.AsyncClient, api_base: str, address: str) -> float:
+    """Return BTC balance for ``address`` using Blockstream API."""
+
+    try:
+        resp = await client.get(f"{api_base}/address/{address}")
+        resp.raise_for_status()
+        data = resp.json()
+        chain = data.get("chain_stats", {})
+        funded = float(chain.get("funded_txo_sum", 0))
+        spent = float(chain.get("spent_txo_sum", 0))
+        return (funded - spent) / 1e8
+    except Exception:
+        return 0.0
+
+
+async def _gather_balances(settings: Dict[str, Any]) -> Dict[str, float]:
+    """Fetch balances for all wallets defined in ``settings``."""
+
+    totals = {"BTC": 0.0, "ETH": 0.0, "USDT": 0.0, "USDC": 0.0}
+
+    eth_cfg = settings.get("eth", {})
+    btc_cfg = settings.get("btc", {})
+    api_key = settings.get("etherscan_api_key", "")
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        for mm in settings.get("mm", []):
+            eth = mm.get("eth", {})
+            btc = mm.get("btc", {})
+
+            eth_addrs: Iterable[str] = eth.get("hot", []) + eth.get("cold", [])
+            btc_addrs: Iterable[str] = btc.get("hot", []) + btc.get("cold", [])
+
+            for addr in eth_addrs:
+                totals["ETH"] += await _eth_balance(client, eth_cfg.get("api_base", ""), api_key, addr)
+                totals["USDT"] += await _token_balance(
+                    client,
+                    eth_cfg.get("api_base", ""),
+                    api_key,
+                    eth_cfg.get("usdt_contract", ""),
+                    addr,
+                )
+                totals["USDC"] += await _token_balance(
+                    client,
+                    eth_cfg.get("api_base", ""),
+                    api_key,
+                    eth_cfg.get("usdc_contract", ""),
+                    addr,
+                )
+
+            for addr in btc_addrs:
+                totals["BTC"] += await _btc_balance(client, btc_cfg.get("api_base", ""), addr)
+
+    return totals
+
+
+def _append_history(snapshot: Dict[str, Any], path: Path) -> None:
+    """Append ``snapshot`` to JSON history at ``path``."""
+
+    try:
+        history = json.loads(path.read_text())
+    except Exception:
+        history = []
+
+    history.append(snapshot)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(history))
+
+
+async def refresh_holdings(settings_path: str = "settings.json") -> Dict[str, Any]:
+    """Fetch balances and persist a new snapshot.
+
+    Parameters
+    ----------
+    settings_path:
+        Path to the settings JSON file.  If the file does not exist a
+        :mod:`settings.example.json` will be used instead.
+
+    Returns
+    -------
+    dict
+        Snapshot in the form ``{"time": ..., "totals": {...}}``.
+    """
+
+    cfg_path = Path(settings_path)
+    if not cfg_path.exists():
+        cfg_path = Path("settings.example.json")
+
+    settings = json.loads(cfg_path.read_text())
+
+    totals = await _gather_balances(settings)
+
+    snapshot = {
+        "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "totals": totals,
+    }
+
+    _append_history(snapshot, Path("data/holdings_history.json"))
+
+    return snapshot
+

--- a/server.py
+++ b/server.py
@@ -1,160 +1,226 @@
-from fastapi import FastAPI
+"""FastAPI application serving market monitoring data.
+
+The server exposes endpoints for refreshing and retrieving on‑chain holdings
+and derivatives metrics.  Data is periodically refreshed based on the
+``refresh_interval_sec`` value in ``settings.json`` (falling back to
+``settings.example.json`` if the former is absent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse
+
+from derivatives import append_history as append_deriv_history
+from derivatives import fetch_all as fetch_derivs
+from holdings import refresh_holdings
 
 app = FastAPI()
 
-# demo data
-DEMO_SNAPSHOT = {
-    "time": "2025-09-02T12:00:00Z",
-    "totals": {"BTC": 123.45, "ETH": 4567.89, "USDT": 2000000, "USDC": 1500000}
-}
-# 历史演示（用于折线图）
-DEMO_HISTORY = {
-    "time": [f"12:{str(i).zfill(2)}" for i in range(0,30,5)],
-    "BTC":  [120,121,122,123,124,125],
-    "ETH":  [4500,4520,4550,4560,4568,4570],
-    "USDT": [1990000,1995000,1998000,2000000,2003000,2005000],
-    "USDC": [1495000,1497000,1499000,1500000,1501000,1502000]
-}
-DEMO_DERIVS = {
-    "BTCUSDT": {
-        "funding": [0.01, 0.015, 0.02, 0.018, 0.022, 0.019],
-        "basis": [50, 70, 40, 55, 65, 60],
-        "oi": [1000, 1200, 900, 1100, 1300, 1250],
-        "timestamps": ["12:00","12:05","12:10","12:15","12:20","12:25"]
-    },
-    "ETHUSDT": {
-        "funding": [0.008, 0.011, 0.013, 0.012, 0.014, 0.013],
-        "basis": [12, 18, 9, 14, 16, 13],
-        "oi": [600, 720, 680, 700, 740, 735],
-        "timestamps": ["12:00","12:05","12:10","12:15","12:20","12:25"]
-    }
-}
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+
+
+def _settings_path() -> Path:
+    p = Path("settings.json")
+    if not p.exists():
+        p = Path("settings.example.json")
+    return p
+
+
+def _load_history(path: Path) -> list[Dict[str, Any]]:
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return []
+
+
+async def _refresh_once() -> Dict[str, Any]:
+    """Fetch holdings and derivatives and persist them to disk."""
+
+    snapshot = await refresh_holdings(str(_settings_path()))
+    ts = snapshot["time"]
+    for sym in ("BTCUSDT", "ETHUSDT"):
+        deriv = await fetch_derivs(sym)
+        deriv["time"] = ts
+        append_deriv_history(sym, deriv)
+    return snapshot
+
+
+# Global state updated on each refresh
+LAST_SNAPSHOT: Dict[str, Any] | None = None
+
+
+async def _refresh_loop() -> None:
+    """Background task that periodically refreshes data."""
+
+    cfg = json.loads(_settings_path().read_text())
+    interval = int(cfg.get("refresh_interval_sec", 300))
+    while True:
+        global LAST_SNAPSHOT
+        LAST_SNAPSHOT = await _refresh_once()
+        await asyncio.sleep(interval)
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    global LAST_SNAPSHOT
+    history = _load_history(Path("data/holdings_history.json"))
+    if history:
+        LAST_SNAPSHOT = history[-1]
+    asyncio.create_task(_refresh_loop())
+
+
+# ---------------------------------------------------------------------------
+# HTML front‑end
+
 
 @app.get("/", response_class=HTMLResponse)
-def index():
-    return """
-<!doctype html>
-<meta charset=\"utf-8\">
-<title>MarketMonitoring v4.9</title>
-<script src=\"https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js\"></script>
-<h1>做市商监控 v4.9</h1>
-<div style=\"display:flex;gap:8px;flex-wrap:wrap\">
-  <button onclick=\"showTab('holdings')\">持仓</button>
-  <button onclick=\"showTab('predict')\">预测</button>
-  <button onclick=\"showTab('derivs')\">衍生品</button>
-</div>
+def index() -> str:
+    """Serve a very small ECharts based front‑end."""
 
-<!-- Tab: 持仓 -->
-<div id=\"tab-holdings\">
-  <div id=\"holdings-bar\" style=\"width:800px;height:320px;border:1px solid #ccc;margin-top:10px\"></div>
-  <div id=\"holdings-line\" style=\"width:800px;height:320px;border:1px solid #ccc;margin-top:10px\"></div>
-</div>
+    return (
+        "<!doctype html>\n"
+        "<meta charset='utf-8'>\n"
+        "<title>MarketMonitoring</title>\n"
+        "<script src='https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js'></script>\n"
+        "<h1>Market Monitoring</h1>\n"
+        "<div style='display:flex;gap:8px;flex-wrap:wrap'>\n"
+        "  <button onclick=\"showTab('holdings')\">持仓</button>\n"
+        "  <button onclick=\"showTab('predict')\">预测</button>\n"
+        "  <button onclick=\"showTab('derivs')\">衍生品</button>\n"
+        "</div>\n"
+        "<div id='tab-holdings'>\n"
+        "  <div id='holdings-bar' style='width:800px;height:320px;border:1px solid #ccc;margin-top:10px'></div>\n"
+        "  <div id='holdings-line' style='width:800px;height:320px;border:1px solid #ccc;margin-top:10px'></div>\n"
+        "</div>\n"
+        "<div id='tab-predict' style='display:none'>\n"
+        "  <div id='predict-json' style='margin-top:10px'></div>\n"
+        "</div>\n"
+        "<div id='tab-derivs' style='display:none'>\n"
+        "  <div style='display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:10px'>\n"
+        "    <div><h3>BTCUSDT Funding/Basis/OI</h3><div id='derivs-btc' style='width:100%;height:320px;border:1px solid #ccc'></div></div>\n"
+        "    <div><h3>ETHUSDT Funding/Basis/OI</h3><div id='derivs-eth' style='width:100%;height:320px;border:1px solid #ccc'></div></div>\n"
+        "  </div>\n"
+        "</div>\n"
+        "<script>\n"
+        "function showTab(tab){\n"
+        "  document.getElementById('tab-holdings').style.display = (tab==='holdings')?'block':'none';\n"
+        "  document.getElementById('tab-predict').style.display  = (tab==='predict')?'block':'none';\n"
+        "  document.getElementById('tab-derivs').style.display   = (tab==='derivs')?'block':'none';\n"
+        "}\n"
+        "async function load(){\n"
+        "  let snap = await fetch('/mm/holdings').then(r=>r.json());\n"
+        "  let bar = echarts.init(document.getElementById('holdings-bar'));\n"
+        "  bar.setOption({title:{text:'最近快照'},xAxis:{type:'category',data:Object.keys(snap.totals)},yAxis:{type:'value'},series:[{data:Object.values(snap.totals),type:'bar'}]});\n"
+        "  let hist = await fetch('/chart/holdings').then(r=>r.json());\n"
+        "  let line = echarts.init(document.getElementById('holdings-line'));\n"
+        "  line.setOption({tooltip:{trigger:'axis'},legend:{data:['BTC','ETH','USDT','USDC']},xAxis:{type:'category',data:hist.time},yAxis:{type:'value'},series:[{name:'BTC',type:'line',data:hist.BTC},{name:'ETH',type:'line',data:hist.ETH},{name:'USDT',type:'line',data:hist.USDT},{name:'USDC',type:'line',data:hist.USDC}]});\n"
+        "  let pred1 = await fetch('/predict/BTCUSDT').then(r=>r.json());\n"
+        "  let pred2 = await fetch('/predict/ETHUSDT').then(r=>r.json());\n"
+        "  document.getElementById('predict-json').innerHTML='<h3>预测信号</h3><pre>'+JSON.stringify([pred1,pred2],null,2)+'</pre>';\n"
+        "  let dbtc = await fetch('/chart/derivs?symbol=BTCUSDT').then(r=>r.json());\n"
+        "  let deth = await fetch('/chart/derivs?symbol=ETHUSDT').then(r=>r.json());\n"
+        "  let btcChart = echarts.init(document.getElementById('derivs-btc'));\n"
+        "  btcChart.setOption({tooltip:{trigger:'axis'},legend:{data:['funding','basis','oi']},xAxis:{type:'category',data:dbtc.timestamps},yAxis:{type:'value'},series:[{name:'funding',type:'line',data:dbtc.funding},{name:'basis',type:'line',data:dbtc.basis},{name:'oi',type:'line',data:dbtc.oi}]});\n"
+        "  let ethChart = echarts.init(document.getElementById('derivs-eth'));\n"
+        "  ethChart.setOption({tooltip:{trigger:'axis'},legend:{data:['funding','basis','oi']},xAxis:{type:'category',data:deth.timestamps},yAxis:{type:'value'},series:[{name:'funding',type:'line',data:deth.funding},{name:'basis',type:'line',data:deth.basis},{name:'oi',type:'line',data:deth.oi}]});\n"
+        "}\n"
+        "setInterval(load,5000);\nload();\n</script>"
+    )
 
-<!-- Tab: 预测 -->
-<div id=\"tab-predict\" style=\"display:none\">
-  <div id=\"predict-json\" style=\"margin-top:10px\"></div>
-</div>
 
-<!-- Tab: 衍生品 -->
-<div id=\"tab-derivs\" style=\"display:none\">
-  <div style=\"display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:10px\">
-    <div>
-      <h3>BTCUSDT Funding/Basis/OI</h3>
-      <div id=\"derivs-btc\" style=\"width:100%;height:320px;border:1px solid #ccc\"></div>
-    </div>
-    <div>
-      <h3>ETHUSDT Funding/Basis/OI</h3>
-      <div id=\"derivs-eth\" style=\"width:100%;height:320px;border:1px solid #ccc\"></div>
-    </div>
-  </div>
-</div>
+# ---------------------------------------------------------------------------
+# REST endpoints
 
-<script>
-function showTab(tab){
-  document.getElementById('tab-holdings').style.display = (tab==='holdings')?'block':'none';
-  document.getElementById('tab-predict').style.display  = (tab==='predict')?'block':'none';
-  document.getElementById('tab-derivs').style.display   = (tab==='derivs')?'block':'none';
-}
-async function load(){
-  // holdings bar
-  let snap = await fetch('/mm/holdings').then(r=>r.json());
-  let bar = echarts.init(document.getElementById('holdings-bar'));
-  bar.setOption({
-    title:{text:'最近快照'},
-    xAxis:{type:'category',data:Object.keys(snap.totals)},
-    yAxis:{type:'value'},
-    series:[{data:Object.values(snap.totals),type:'bar'}]
-  });
-  // holdings line
-  let hist = await fetch('/chart/holdings').then(r=>r.json());
-  let line = echarts.init(document.getElementById('holdings-line'));
-  line.setOption({
-    tooltip:{trigger:'axis'},
-    legend:{data:['BTC','ETH','USDT','USDC']},
-    xAxis:{type:'category',data:hist.time},
-    yAxis:{type:'value'},
-    series:[
-      {name:'BTC', type:'line', data:hist.BTC},
-      {name:'ETH', type:'line', data:hist.ETH},
-      {name:'USDT', type:'line', data:hist.USDT},
-      {name:'USDC', type:'line', data:hist.USDC},
-    ]
-  });
-  // predict
-  let pred1 = await fetch('/predict/BTCUSDT').then(r=>r.json());
-  let pred2 = await fetch('/predict/ETHUSDT').then(r=>r.json());
-  document.getElementById('predict-json').innerHTML =
-    '<h3>预测信号</h3><pre>'+JSON.stringify([pred1,pred2],null,2)+'</pre>';
-  // derivs
-  let dbtc = await fetch('/chart/derivs?symbol=BTCUSDT').then(r=>r.json());
-  let deth = await fetch('/chart/derivs?symbol=ETHUSDT').then(r=>r.json());
-  let btcChart = echarts.init(document.getElementById('derivs-btc'));
-  btcChart.setOption({
-    tooltip:{trigger:'axis'},
-    legend:{data:['funding','basis','oi']},
-    xAxis:{type:'category',data:dbtc.timestamps},
-    yAxis:{type:'value'},
-    series:[
-      {name:'funding', type:'line', data:dbtc.funding},
-      {name:'basis',   type:'line', data:dbtc.basis},
-      {name:'oi',      type:'line', data:dbtc.oi}
-    ]
-  });
-  let ethChart = echarts.init(document.getElementById('derivs-eth'));
-  ethChart.setOption({
-    tooltip:{trigger:'axis'},
-    legend:{data:['funding','basis','oi']},
-    xAxis:{type:'category',data:deth.timestamps},
-    yAxis:{type:'value'},
-    series:[
-      {name:'funding', type:'line', data:deth.funding},
-      {name:'basis',   type:'line', data:deth.basis},
-      {name:'oi',      type:'line', data:deth.oi}
-    ]
-  });
-}
-setInterval(load, 5000);
-load();
-</script>
-"""
+
+@app.post("/mm/refresh")
+async def refresh_endpoint() -> Dict[str, Any]:
+    """Trigger an immediate refresh of data."""
+
+    global LAST_SNAPSHOT
+    LAST_SNAPSHOT = await _refresh_once()
+    return LAST_SNAPSHOT
+
 
 @app.get("/mm/holdings")
-def mm_holdings():
-    return DEMO_SNAPSHOT
+def mm_holdings() -> Dict[str, Any]:
+    """Return the latest holdings snapshot."""
+
+    return LAST_SNAPSHOT or {"time": None, "totals": {}}
+
 
 @app.get("/chart/holdings")
-def chart_holdings():
-    return DEMO_HISTORY
+def chart_holdings() -> Dict[str, Any]:
+    """Return holdings history as time series."""
+
+    hist = _load_history(Path("data/holdings_history.json"))
+    return {
+        "time": [h["time"] for h in hist],
+        "BTC": [h["totals"].get("BTC", 0) for h in hist],
+        "ETH": [h["totals"].get("ETH", 0) for h in hist],
+        "USDT": [h["totals"].get("USDT", 0) for h in hist],
+        "USDC": [h["totals"].get("USDC", 0) for h in hist],
+    }
+
 
 @app.get("/predict/{symbol}")
-def predict(symbol: str):
+def predict(symbol: str) -> Dict[str, Any]:
+    """Return simple differential prediction score."""
+
+    hist = _load_history(Path("data/holdings_history.json"))
+    if len(hist) < 2:
+        return {"symbol": symbol.upper(), "score": 0.0, "signal": "neutral"}
+
+    last, prev = hist[-1], hist[-2]
     sym = symbol.upper()
-    # demo: ETH 略低，BTC 略高
-    score = 0.18 if sym == "BTCUSDT" else 0.07
-    sig = "bullish" if score>0 else "bearish" if score<0 else "neutral"
+    target = "BTC" if sym == "BTCUSDT" else "ETH"
+
+    d_target = last["totals"].get(target, 0) - prev["totals"].get(target, 0)
+    d_usdt = last["totals"].get("USDT", 0) - prev["totals"].get("USDT", 0)
+    d_usdc = last["totals"].get("USDC", 0) - prev["totals"].get("USDC", 0)
+    score = d_target - 0.8 * d_usdt - 0.4 * d_usdc
+
+    sig = "bullish" if score > 0 else "bearish" if score < 0 else "neutral"
     return {"symbol": sym, "score": score, "signal": sig}
 
+
 @app.get("/chart/derivs")
-def chart_derivs(symbol: str):
-    return DEMO_DERIVS.get(symbol.upper(), DEMO_DERIVS["BTCUSDT"])
+def chart_derivs(symbol: str) -> Dict[str, Any]:
+    """Return derivatives history for ``symbol``."""
+
+    path = Path(f"data/derivs_{symbol.upper()}.json")
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {"funding": [], "basis": [], "oi": [], "timestamps": []}
+
+
+@app.post("/labels/import")
+async def labels_import(file: UploadFile = File(...)) -> Any:
+    """Import wallet labels from CSV or JSON and write back to settings."""
+
+    data = await file.read()
+    try:
+        if file.filename.lower().endswith(".json"):
+            labels = json.loads(data.decode())
+        else:
+            reader = csv.reader(io.StringIO(data.decode()))
+            labels = [row for row in reader if row]
+    except Exception:  # pragma: no cover - invalid input
+        return JSONResponse({"error": "invalid format"}, status_code=400)
+
+    _settings_path().write_text(json.dumps(labels, indent=2))
+    return {"status": "ok"}
+
+
+# End of file
+


### PR DESCRIPTION
## Summary
- add on-chain balance fetcher using Etherscan and Blockstream
- gather derivatives metrics from Binance, Bybit and OKX and record history
- replace demo server with FastAPI app serving refresh, holdings, prediction and derivatives endpoints

## Testing
- `python -m py_compile holdings.py derivatives.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6c33af3b88329addd4bc4c6354e4e