### PR TITLE
Add aggregated open-order charts for BTCUSDT and ETHUSDT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - Tab1: 最近持仓快照柱状图 + 历史折线
   - Tab2: 预测信号 (BTCUSDT, ETHUSDT)
   - Tab3: 衍生品 Funding / Basis / OI 曲线（**BTCUSDT & ETHUSDT 并排展示**）
+  - Tab4: 三大交易所挂单统计（BTCUSDT & ETHUSDT）
 
 ## 使用方法
 ```bash

--- a/orderbook.py
+++ b/orderbook.py
@@ -1,0 +1,74 @@
+"""Aggregate open buy/sell orders across major exchanges."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Tuple, Dict
+
+import httpx
+
+
+async def _binance(symbol: str) -> Tuple[float, float]:
+    """Return summed (bids, asks) from Binance futures orderbook."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                "https://fapi.binance.com/fapi/v1/depth",
+                params={"symbol": symbol, "limit": 100},
+            )
+            resp.raise_for_status()
+            book = resp.json()
+            bids = sum(float(b[1]) for b in book.get("bids", []))
+            asks = sum(float(a[1]) for a in book.get("asks", []))
+            return bids, asks
+    except Exception:
+        return 0.0, 0.0
+
+
+async def _bybit(symbol: str) -> Tuple[float, float]:
+    """Return summed (bids, asks) from Bybit linear swaps orderbook."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                "https://api.bybit.com/v5/market/orderbook",
+                params={"category": "linear", "symbol": symbol, "limit": 100},
+            )
+            resp.raise_for_status()
+            data = resp.json().get("result", {}).get("list", [])
+            if not data:
+                return 0.0, 0.0
+            item = data[0]
+            bids = sum(float(b[1]) for b in item.get("b", []))
+            asks = sum(float(a[1]) for a in item.get("a", []))
+            return bids, asks
+    except Exception:
+        return 0.0, 0.0
+
+
+async def _okx(symbol: str) -> Tuple[float, float]:
+    """Return summed (bids, asks) from OKX swaps orderbook."""
+    inst = symbol.replace("USDT", "-USDT") + "-SWAP"
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                "https://www.okx.com/api/v5/market/books",
+                params={"instId": inst, "sz": 100},
+            )
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+            if not data:
+                return 0.0, 0.0
+            book = data[0]
+            bids = sum(float(b[1]) for b in book.get("bids", []))
+            asks = sum(float(a[1]) for a in book.get("asks", []))
+            return bids, asks
+    except Exception:
+        return 0.0, 0.0
+
+
+async def fetch(symbol: str) -> Dict[str, float]:
+    """Aggregate open buy/sell volumes across Binance, Bybit and OKX."""
+    results = await asyncio.gather(_binance(symbol), _bybit(symbol), _okx(symbol))
+    buy = sum(r[0] for r in results)
+    sell = sum(r[1] for r in results)
+    return {"symbol": symbol, "buy": buy, "sell": sell}


### PR DESCRIPTION
## Summary
- add new "挂单" tab to display combined bid/ask volumes for BTCUSDT and ETHUSDT
- create orderbook aggregation module fetching data from Binance, Bybit, and OKX

## Testing
- `python -m py_compile server.py orderbook.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6c7e9d540832981c53eeffd50466c