### PR TITLE
fix: use project-relative paths for holdings data

### DIFF
--- a/derivatives.py
+++ b/derivatives.py
@@ -25,6 +25,9 @@ from typing import Any, Dict, Tuple
 import httpx
 
 
+# Base directory to resolve data paths independent of CWD
+BASE_DIR = Path(__file__).resolve().parent
+
 async def _binance(symbol: str) -> Tuple[float, float, float]:
     """Return ``(funding, basis, oi)`` from Binance futures."""
 
@@ -145,7 +148,7 @@ async def fetch_all(symbol: str) -> Dict[str, float]:
 def append_history(symbol: str, data: Dict[str, Any], base: Path | None = None) -> None:
     """Append ``data`` to a derivatives history file for ``symbol``."""
 
-    base = base or Path("data")
+    base = base or BASE_DIR / "data"
     path = base / f"derivs_{symbol}.json"
 
     try:

--- a/holdings.py
+++ b/holdings.py
@@ -27,6 +27,10 @@ import httpx
 ETH_DECIMALS = 10**18
 TOKEN_DECIMALS = 10**6  # USDT/USDC on Ethereum use 6 decimals
 
+# Base directory of the project to allow running from any working directory
+BASE_DIR = Path(__file__).resolve().parent
+HISTORY_PATH = BASE_DIR / "data" / "holdings_history.json"
+
 
 async def _eth_balance(client: httpx.AsyncClient, api_base: str, api_key: str, address: str) -> float:
     """Return ETH balance for ``address`` in whole ETH."""
@@ -166,7 +170,7 @@ async def refresh_holdings(settings_path: str = "settings.json") -> Dict[str, An
 
     cfg_path = Path(settings_path)
     if not cfg_path.exists():
-        cfg_path = Path("settings.example.json")
+        cfg_path = BASE_DIR / "settings.example.json"
 
     settings = json.loads(cfg_path.read_text())
 
@@ -177,7 +181,7 @@ async def refresh_holdings(settings_path: str = "settings.json") -> Dict[str, An
         "totals": totals,
     }
 
-    _append_history(snapshot, Path("data/holdings_history.json"))
+    _append_history(snapshot, HISTORY_PATH)
 
     return snapshot
 

--- a/server.py
+++ b/server.py
@@ -25,14 +25,18 @@ from holdings import refresh_holdings
 app = FastAPI()
 
 
+# Base directory of the project – ensures paths work regardless of CWD
+BASE_DIR = Path(__file__).resolve().parent
+
+
 # ---------------------------------------------------------------------------
 # Utility helpers
 
 
 def _settings_path() -> Path:
-    p = Path("settings.json")
+    p = BASE_DIR / "settings.json"
     if not p.exists():
-        p = Path("settings.example.json")
+        p = BASE_DIR / "settings.example.json"
     return p
 
 
@@ -51,7 +55,7 @@ async def _refresh_once() -> Dict[str, Any]:
     for sym in ("BTCUSDT", "ETHUSDT"):
         deriv = await fetch_derivs(sym)
         deriv["time"] = ts
-        append_deriv_history(sym, deriv)
+        append_deriv_history(sym, deriv, BASE_DIR / "data")
     return snapshot
 
 
@@ -73,7 +77,7 @@ async def _refresh_loop() -> None:
 @app.on_event("startup")
 async def _startup() -> None:
     global LAST_SNAPSHOT
-    history = _load_history(Path("data/holdings_history.json"))
+    history = _load_history(BASE_DIR / "data" / "holdings_history.json")
     if history:
         LAST_SNAPSHOT = history[-1]
     asyncio.create_task(_refresh_loop())
@@ -168,7 +172,7 @@ def mm_holdings() -> Dict[str, Any]:
 def chart_holdings() -> Dict[str, Any]:
     """Return holdings history as time series."""
 
-    hist = _load_history(Path("data/holdings_history.json"))
+    hist = _load_history(BASE_DIR / "data" / "holdings_history.json")
     return {
         "time": [h["time"] for h in hist],
         "BTC": [h["totals"].get("BTC", 0) for h in hist],
@@ -182,7 +186,7 @@ def chart_holdings() -> Dict[str, Any]:
 def predict(symbol: str) -> Dict[str, Any]:
     """Return simple differential prediction score."""
 
-    hist = _load_history(Path("data/holdings_history.json"))
+    hist = _load_history(BASE_DIR / "data" / "holdings_history.json")
     if len(hist) < 2:
         return {"symbol": symbol.upper(), "score": 0.0, "signal": "neutral"}
 
@@ -203,7 +207,7 @@ def predict(symbol: str) -> Dict[str, Any]:
 def chart_derivs(symbol: str) -> Dict[str, Any]:
     """Return derivatives history for ``symbol``."""
 
-    path = Path(f"data/derivs_{symbol.upper()}.json")
+    path = BASE_DIR / "data" / f"derivs_{symbol.upper()}.json"
     try:
         return json.loads(path.read_text())
     except Exception:


### PR DESCRIPTION
## Summary
- ensure path handling uses module directory to prevent missing holdings
- update server, holdings, derivatives modules to use BASE_DIR for data/history

## Testing
- `python -m py_compile holdings.py server.py derivatives.py`
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_b_68b6c86b42e48329bcb623e391621ec2