### PR TITLE
feat: configurable pair monitoring with SQLite price history

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -25,6 +25,15 @@
     "addresses": [],
     "clusters": []
   },
+  "symbols": [
+    "BTCUSDT",
+    "ETHUSDT",
+    "SOLUSDT",
+    "XLMUSDT",
+    "XRPUSDT",
+    "AAVEUSDT",
+    "BNBUSDT"
+  ],
   "mm": [
     {
       "name": "Wintermute",


### PR DESCRIPTION
## Summary
- allow configuring monitored trading pairs via `settings.json`
- persist spot prices in a new SQLite table for historical analysis
- display derivatives metrics per pair using last 24h data and expand order book charts for all pairs

## Testing
- `python -m py_compile db.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7b6b3852883299c01b44ed640d998