### PR TITLE
Align order book charts with SOLUSDT baseline

### DIFF
--- a/server.py
+++ b/server.py
@@ -316,7 +316,7 @@ def index() -> str:
         "  for(let s of derivSyms){\n"
         "    let ob=await fetch(`/chart/orders?symbol=${s}`).then(r=>r.json());\n"
         "    let chart=echarts.init(document.getElementById(`orders-${s.toLowerCase()}`));\n"
-        "    chart.setOption({tooltip:{},legend:{data:['buy','sell']},xAxis:{type:'category',data:ob.prices.map(p=>p.toString())},yAxis:{type:'value'},series:[{name:'buy',data:ob.buy,type:'bar'},{name:'sell',data:ob.sell,type:'bar'}]});\n"
+        "    chart.setOption({tooltip:{},legend:{data:['buy','sell']},xAxis:{type:'category',data:ob.prices.map(p=>Number(p).toFixed(2))},yAxis:{type:'value'},series:[{name:'buy',data:ob.buy,type:'bar'},{name:'sell',data:ob.sell,type:'bar'}]});\n"
         "  }\n"
         "}\n"
         "setInterval(load,5000);\nload();\n</script>\n"


### PR DESCRIPTION
## Summary
- unify order book bucket sizing to SOLUSDT-style precision across symbols
- round price buckets to two decimal places and display them with fixed formatting in charts

## Testing
- `pytest`
- `python -m py_compile orderbook.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7ce3e23a88329a254416fdcb5a690