### PR TITLE
fix: specify UTF-8 when reading index.html

### DIFF
--- a/server.py
+++ b/server.py
@@ -244,7 +244,11 @@ async def _maybe_backfill_24h() -> None:
 @app.get("/", response_class=HTMLResponse)
 def index() -> str:
     """Serve a very small ECharts based front-end."""
-    tpl = (BASE_DIR / "index.html").read_text()
+    # Explicitly decode index.html as UTF-8 so that the application works on
+    # systems whose default locale uses a different encoding (e.g. GBK on
+    # Windows). Without this, reading the file with ``Path.read_text`` can
+    # raise ``UnicodeDecodeError`` when the HTML contains non-ASCII characters.
+    tpl = (BASE_DIR / "index.html").read_text(encoding="utf-8")
     return tpl.replace("__SYMS__", json.dumps(_symbols()))
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prevent UnicodeDecodeError on Windows by explicitly decoding index.html as UTF-8

## Testing
- `python -m py_compile server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b7f75126fc8329bc22dbbc5e9c4c5b