### PR TITLE
Add trade volume distribution chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,18 @@ async function load(){
     let td=await fetch(`/chart/trades?symbol=${currentSym}`).then(r=>r.json());
     let dec=sym4.includes(currentSym)?4:2;
     let tc=echarts.init(document.getElementById('trades-chart'));
-    tc.setOption({tooltip:{trigger:'axis'},xAxis:{type:'category',data:toUTC8(td.times)},yAxis:{type:'value',axisLabel:{formatter:v=>Number(v).toFixed(dec)}},series:[{type:'line',data:td.prices,showSymbol:false,markLine:{silent:true,data:[{yAxis:td.upper,lineStyle:{color:'red'}},{yAxis:td.lower,lineStyle:{color:'green'}}]}}]});
+    tc.setOption({
+      tooltip:{trigger:'axis'},
+      xAxis:{type:'category',data:toUTC8(td.times)},
+      yAxis:[
+        {type:'value',axisLabel:{formatter:v=>Number(v).toFixed(dec)}},
+        {type:'value',axisLabel:{formatter:v=>Number(v).toLocaleString()}},
+      ],
+      series:[
+        {type:'line',data:td.prices,showSymbol:false,markLine:{silent:true,data:[{yAxis:td.upper,lineStyle:{color:'red'}},{yAxis:td.lower,lineStyle:{color:'green'}}]}},
+        {type:'bar',data:td.volumes,yAxisIndex:1,barWidth:'60%',itemStyle:{color:'#91CC75'}},
+      ]
+    });
   }
 }
 setInterval(load,5000);load();

--- a/server.py
+++ b/server.py
@@ -481,7 +481,15 @@ async def chart_trades(symbol: str) -> Dict[str, Any]:
                 break
         lower = l if l is not None else pairs[0][0]
         upper = u if u is not None else pairs[-1][0]
-    return {"symbol": sym, "times": times, "prices": closes, "lower": lower, "upper": upper}
+
+    return {
+        "symbol": sym,
+        "times": times,
+        "prices": closes,
+        "volumes": volumes,
+        "lower": lower,
+        "upper": upper,
+    }
 
 
 @app.post("/labels/import")


### PR DESCRIPTION
## Summary
- Include volume data in `/chart/trades` API and expose volumes alongside prices
- Plot trading volume distribution on trades tab with dual-axis line/bar chart

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b800e8adb083299004b7a3ec7b3e45