### PR TITLE
Add price marker and full-width order book axis

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,18 @@ async function load(){
     let ob=await fetch(`/chart/orders?symbol=${currentSym}`).then(r=>r.json());
     let chart=echarts.init(document.getElementById('orders-chart'));
     let dec=sym4.includes(currentSym)?4:2;
-    chart.setOption({tooltip:{},legend:{data:['buy','sell']},xAxis:{type:'category',data:ob.prices.map(p=>Number(p).toFixed(dec))},yAxis:{type:'value'},series:[{name:'buy',data:ob.buy,type:'bar'},{name:'sell',data:ob.sell,type:'bar'}]});
+    let priceStr=Number(ob.price).toFixed(dec);
+    chart.setOption({
+      tooltip:{},
+      legend:{data:['buy','sell']},
+      grid:{left:0,right:0,containLabel:true},
+      xAxis:{type:'category',data:ob.prices.map(p=>Number(p).toFixed(dec)),boundaryGap:false},
+      yAxis:{type:'value'},
+      series:[
+        {name:'buy',data:ob.buy,type:'bar',markLine:{symbol:'none',lineStyle:{type:'dashed'},data:[{xAxis:priceStr}]}},
+        {name:'sell',data:ob.sell,type:'bar'}
+      ]
+    });
   }else if(currentTab==='trades'){
     let wrap=document.getElementById('trades-wrap');
     if(!wrap.hasChildNodes()){

--- a/orderbook.py
+++ b/orderbook.py
@@ -118,5 +118,18 @@ async def fetch(symbol: str) -> Dict[str, Any]:
     prices = sorted(buckets.keys())
     buy = [buckets[p]["buy"] for p in prices]
     sell = [buckets[p]["sell"] for p in prices]
+
+    # Round prices to the desired precision for output and current price
     prices = [round(p, decimals) for p in prices]
-    return {"symbol": symbol, "prices": prices, "buy": buy, "sell": sell}
+    price = round(mid, decimals)
+
+    # Ensure the current price exists in the axis to draw mark line
+    if price not in prices:
+        idx = 0
+        while idx < len(prices) and prices[idx] < price:
+            idx += 1
+        prices.insert(idx, price)
+        buy.insert(idx, 0.0)
+        sell.insert(idx, 0.0)
+
+    return {"symbol": symbol, "price": price, "prices": prices, "buy": buy, "sell": sell}


### PR DESCRIPTION
## Summary
- Add current price marker to order book chart and ensure x-axis fills width
- Return current price in order book API and insert placeholder bucket

## Testing
- `python -m py_compile orderbook.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b8013c177c8329ba5dee81bad7e7a9