### PR TITLE
Fix PEPEUSDT orderbook precision

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ const symDecimals={
   'XLMUSDT':4,
   'DOGEUSDT':4,
   'SUIUSDT':4,
-  'PEPEUSDT':4,
+  'PEPEUSDT':8,
   '1000PEPEUSDT':7,
   'PUMPUSDT':6,
   'FARTCOINUSDT':4,

--- a/orderbook.py
+++ b/orderbook.py
@@ -93,7 +93,7 @@ async def fetch(symbol: str) -> Dict[str, Any]:
         "XLMUSDT": 4,
         "DOGEUSDT": 4,
         "SUIUSDT": 4,
-        "PEPEUSDT": 4,
+        "PEPEUSDT": 8,
         "1000PEPEUSDT": 7,
         "PUMPUSDT": 6,
         "FARTCOINUSDT": 4,


### PR DESCRIPTION
## Summary
- handle PEPEUSDT price precision correctly in orderbook aggregation
- update frontend decimals for PEPEUSDT so order charts display accurately

## Testing
- `python -m py_compile orderbook.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b80c19b9948329ba00c42405604684