### PR TITLE
Emphasize volume bounds on trade chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,16 @@ async function load(){
         {type:'value',axisLabel:{formatter:v=>Number(v).toLocaleString()}},
       ],
       series:[
-        {type:'line',data:td.prices,showSymbol:false,markLine:{silent:true,data:[{yAxis:td.upper,lineStyle:{color:'red'}},{yAxis:td.lower,lineStyle:{color:'green'}}]}},
+        {type:'line',data:td.prices,showSymbol:false,
+          markArea:{
+            silent:true,
+            itemStyle:{color:'rgba(30,144,255,0.2)'},
+            data:[
+              [{yAxis:'min'},{yAxis:td.lower}],
+              [{yAxis:td.upper},{yAxis:'max'}]
+            ]
+          }
+        },
         {type:'bar',data:td.volumes,yAxisIndex:1,barWidth:'60%',itemStyle:{color:'#91CC75'}},
       ]
     });


### PR DESCRIPTION
## Summary
- Shade areas outside the central 70% volume range in blue on the trades chart

## Testing
- `python -m compileall .` *(fails: SyntaxError in existing placeholder files)*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b8ea8f8a048329966cc7975c13de1c