### PR TITLE
feat: add selectable derivatives backfill intervals

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,12 @@
 <div id='tab-derivs' style='display:none'>
   <div style='display:flex;align-items:center;gap:10px;margin:10px 0;color:#555;font-size:13px'>
     <span>时间已转换为中国时区 (UTC+8)</span>
-    <button id='btn-backfill' class='menu' onclick='triggerBackfill()'>回填24h</button>
+    <div id='backfill-buttons' style='display:flex;gap:4px'>
+      <button class='menu' onclick='triggerBackfill(1,this)'>回填1h</button>
+      <button class='menu' onclick='triggerBackfill(4,this)'>回填4h</button>
+      <button class='menu' onclick='triggerBackfill(12,this)'>回填12h</button>
+      <button class='menu' onclick='triggerBackfill(24,this)'>回填24h</button>
+    </div>
   </div>
   <h3 id='derivs-sym' style='margin:0'></h3>
   <div id='derivs-wrap' style='display:grid;grid-template-columns:1fr 1fr;gap:10px;align-items:start'></div>
@@ -151,7 +156,7 @@ async function load(){
     }
     let d=await fetch(`/chart/derivs?symbol=${currentSym}`).then(r=>r.json());
     let x=toUTC8(d.timestamps);
-    let p=(d.price||[]).map(v=>Number(v));
+    let p=(d.price||[]).map(v=>v==null?null:Number(v));
     let f=(d.funding||[]).map(v=>Number(v)*100);
     let b=(d.basis||[]).map(v=>Number(v));
     let o=(d.oi||[]).map(v=>Number(v));
@@ -235,12 +240,11 @@ async function load(){
 }
 setInterval(load,5000);load();
 
-async function triggerBackfill(){
-  const btn=document.getElementById('btn-backfill');
+async function triggerBackfill(hours,btn){
   const note=document.getElementById('backfill-note');
-  btn.disabled=true; btn.textContent='回填中...'; note.textContent='';
+  btn.disabled=true; const orig=btn.textContent; btn.textContent='回填中...'; note.textContent='';
   try{
-    const res=await fetch('/backfill/derivs',{method:'POST'});
+    const res=await fetch(`/backfill/derivs?hours=${hours}`,{method:'POST'});
     const data=await res.json();
     note.textContent='回填完成: '+JSON.stringify(data.inserted_points||data);
     // 触发一次加载刷新图表
@@ -248,7 +252,7 @@ async function triggerBackfill(){
   }catch(e){
     note.textContent='回填失败: '+(e?.message||e);
   }finally{
-    btn.disabled=false; btn.textContent='回填24h';
+    btn.disabled=false; btn.textContent=orig;
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- allow custom backfill durations for derivatives data
- show derivatives price correctly when data is missing
- add UI buttons for 1h/4h/12h/24h backfill

## Testing
- `python -m py_compile server.py derivatives.py`


------
https://chatgpt.com/codex/tasks/task_b_68b8f21ba6c083298dbaefe1d8b32a0a