### PR TITLE
Track cancel counts via Binance user stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,12 +230,14 @@ async function load(){
   }else if(currentTab==='cancels'){
     let wrap=document.getElementById('cancels-wrap');
     if(!wrap.hasChildNodes()){
-      wrap.innerHTML=`<h3>${currentSym}</h3><div id='cancels-count' style='font-size:24px;margin-top:10px'></div>`;
+      wrap.innerHTML=`<h3>${currentSym}</h3><div id='cancels-line' style='width:800px;height:320px;border:1px solid #ccc;margin-top:10px'></div>`;
     }else{
       wrap.querySelector('h3').textContent=currentSym;
     }
     let d=await fetch(`/chart/cancels?symbol=${currentSym}`).then(r=>r.json());
-    document.getElementById('cancels-count').textContent='取消数量: '+d.count;
+    let chart=echarts.init(document.getElementById('cancels-line'));
+    let x=toUTC8(d.timestamps);
+    chart.setOption({tooltip:{trigger:'axis'},xAxis:{type:'category',data:x},yAxis:{type:'value'},series:[{data:d.counts,type:'line'}]});
   }
 }
 setInterval(load,5000);load();

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ httpx>=0.24
 python-multipart>=0.0.9
 pysqlite3-binary>=0.5
 # SQLite DB handled via stdlib sqlite3 or pysqlite3 fallback
+websockets>=10
+


### PR DESCRIPTION
## Summary
- listen to Binance user data stream to count canceled orders per symbol
- serve cancel count history via `/chart/cancels`
- render cancellation history as line chart in the cancel tab
- add websockets dependency

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_68b8f622e5e483299c8a57aa0366cd09