### PR TITLE
Handle missing websockets dependency

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,11 @@ from collections import defaultdict
 from fastapi import FastAPI, File, UploadFile, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 import httpx
-import websockets
+
+try:  # Optional dependency used for cancel order monitoring
+    import websockets  # type: ignore
+except ImportError:  # pragma: no cover - dependency may be missing
+    websockets = None  # type: ignore
 
 from derivatives import append_history as append_deriv_history
 from derivatives import fetch_all as fetch_derivs
@@ -300,7 +304,8 @@ async def _startup() -> None:
     # Start background refresh loop after backfill completes
     asyncio.create_task(_refresh_loop())
     asyncio.create_task(_cleanup_loop())
-    asyncio.create_task(_cancel_ws_loop())
+    if websockets is not None:
+        asyncio.create_task(_cancel_ws_loop())
 
 
 async def _maybe_backfill_24h() -> None:


### PR DESCRIPTION
## Summary
- Treat websockets import as optional dependency for cancel order monitoring
- Only start websocket-based cancel loop when websockets library is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b8f9e028e0832999c157eb68e9a227