### PR TITLE
fix: disable colored Uvicorn logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 ```bash
 python -m venv mmenv
 # Windows:
-.\mmenv\Scriptsctivate
+.\mmenv\Scripts\activate
 # macOS/Linux:
 # source mmenv/bin/activate
 pip install -r requirements.txt
-uvicorn server:app --reload --host 0.0.0.0 --port 8000
+uvicorn server:app --reload --host 0.0.0.0 --port 8000 --no-use-colors
 ```
 浏览器访问: http://localhost:8000

--- a/run_server.bat
+++ b/run_server.bat
@@ -1,3 +1,5 @@
 @echo off
+REM Ensure UTF-8 output and disable colored logs on Windows consoles
+set PYTHONUTF8=1
 call mmenv\Scripts\activate
-uvicorn server:app --reload --host 0.0.0.0 --port 8001
+uvicorn server:app --reload --host 0.0.0.0 --port 8001 --no-use-colors


### PR DESCRIPTION
## Summary
- ensure Windows consoles show readable logs by disabling Uvicorn color codes
- document `--no-use-colors` flag and fix activation command in README

## Testing
- `uvicorn --help | rg use-colors`


------
https://chatgpt.com/codex/tasks/task_b_68b90568b38c8329a13e3abbed7b39e3