### PR TITLE
Skip zero values in derivatives charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ async function load(){
     };
     let p=toSeries(d.price);
     let f=toSeries(d.funding,v=>v*100);
-    let b=(d.basis||[]).map(v=>Number(v));
+    let b=toSeries(d.basis);
     let o=toSeries(d.oi);
     let dec=symDecimals[currentSym]??2;
     let mk=(id,name,data,axisFmt,color,autoScale=false)=>{


### PR DESCRIPTION
## Summary
- Treat zero or missing derivative data as null on the server so charts skip gaps
- Use a unified series helper for basis values in the UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9160e1288832992f0760b40d8332a