### PR TITLE
Aggregate open interest only after all exchanges report

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,14 @@ async function load(){
     let mk=(id,name,data,axisFmt,color,autoScale=false)=>{
       let c=echarts.init(document.getElementById(id));
       let yAxis={type:'value',name:name,axisLabel:{formatter:(val)=>axisFmt(val)}};
-      if(autoScale) Object.assign(yAxis,{scale:true,min:'dataMin',max:'dataMax'});
+      if(autoScale){
+        const filtered=data.filter(v=>v!=null);
+        if(filtered.length){
+          const minVal=Math.min(...filtered);
+          const maxVal=Math.max(...filtered);
+          Object.assign(yAxis,{scale:true,min:minVal,max:maxVal});
+        }
+      }
       c.setOption({
         tooltip:{trigger:'axis',formatter:(ps)=>{let p=ps[0];return p.axisValueLabel+'<br/>'+name+': '+axisFmt(p.data);}},
         xAxis:{type:'category',data:x},
@@ -203,7 +210,7 @@ async function load(){
     mk('derivs-price','Price (USD)',p,v=>'$'+Number(v).toFixed(dec),'#3BA272',true);
     mk('derivs-funding','Funding (%)',f,v=>Number(v).toFixed(4)+'%','#5470C6');
     mk('derivs-basis','Basis (USD)',b,v=>'$'+Number(v).toFixed(2),'#EE6666');
-    mk('derivs-oi','Open Interest',o,v=>Number(v).toLocaleString(),'#91CC75',true);
+    mk('derivs-oi','Open Interest',o,v=>Math.round(v).toLocaleString(),'#91CC75',true);
   }else if(currentTab==='orders'){
     initDepthButtons();
     let wrap=document.getElementById('orders-wrap');

--- a/server.py
+++ b/server.py
@@ -180,7 +180,7 @@ async def _refresh_once() -> Dict[str, Any]:
     symbols = _symbols()
     max_points = int(12 * 3600 / interval)
     for sym in symbols:
-        deriv = await fetch_derivs(sym)
+        deriv = await fetch_derivs(sym, ts)
         deriv["time"] = ts
         # write to DB and JSON history for backward compatibility
         try:


### PR DESCRIPTION
## Summary
- store per-exchange open interest in SQLite until all three venues are available
- aggregate derivatives data using cached OI and pass timestamp from server
- auto-scale chart y-axis and round OI labels for clearer display

## Testing
- `python -m py_compile db.py derivatives.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b91dfaa7988329834e5479d94abf4a