### PR TITLE
feat: add real-time price line

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,9 @@ async function refreshPrice(){
   try{
     const data=await fetch(`https://api.binance.com/api/v3/ticker/price?symbol=${currentSym}`).then(r=>r.json());
     latestPrice=Number(data.price)||0;
+    if(currentTab==='trades'){
+      load();
+    }
   }catch(e){
     console.error('Failed to fetch latest price',e);
   }
@@ -364,7 +367,7 @@ async function load(){
   }
 }
 setInterval(load,5000);
-setInterval(refreshPrice,30000);
+setInterval(refreshPrice,60000);
 refreshPrice().then(load);
 
 async function triggerBackfill(hours,btn){


### PR DESCRIPTION
## Summary
- refresh price line when trades tab active
- update price fetch to once per minute

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b95b08597883299349fcaa416d0eb5