### PR TITLE
Add timestamped logging for server

### DIFF
--- a/log_config.json
+++ b/log_config.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "default": {
+      "()": "uvicorn.logging.DefaultFormatter",
+      "fmt": "%(asctime)s %(levelprefix)s %(message)s",
+      "use_colors": null,
+      "datefmt": "%Y-%m-%d %H:%M:%S"
+    },
+    "access": {
+      "()": "uvicorn.logging.AccessFormatter",
+      "fmt": "%(asctime)s %(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S"
+    }
+  },
+  "handlers": {
+    "default": {
+      "formatter": "default",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stderr"
+    },
+    "access": {
+      "formatter": "access",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "loggers": {
+    "uvicorn": {
+      "handlers": ["default"],
+      "level": "INFO"
+    },
+    "uvicorn.error": {
+      "level": "INFO",
+      "handlers": ["default"],
+      "propagate": false
+    },
+    "uvicorn.access": {
+      "handlers": ["access"],
+      "level": "INFO",
+      "propagate": false
+    }
+  }
+}

--- a/run_server.bat
+++ b/run_server.bat
@@ -2,4 +2,4 @@
 REM Ensure UTF-8 output and disable colored logs on Windows consoles
 set PYTHONUTF8=1
 call mmenv\Scripts\activate
-uvicorn server:app --reload --host 0.0.0.0 --port 8001 --no-use-colors
+uvicorn server:app --reload --host 0.0.0.0 --port 8001 --no-use-colors --log-config log_config.json


### PR DESCRIPTION
## Summary
- add log_config.json that formats uvicorn logs with timestamps
- update run_server.bat to load the new logging configuration

## Testing
- `pytest`
- `python -m uvicorn server:app --log-config log_config.json --host 127.0.0.1 --port 8001 --no-use-colors` (verified timestamped request logs)


------
https://chatgpt.com/codex/tasks/task_b_68b961cea33c832984f583e406415164