### PR TITLE
Add time-window controls and auto-scaling for derivative charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       <button class='menu' onclick='triggerBackfill(12,this)'>回填12h</button>
       <button class='menu' onclick='triggerBackfill(24,this)'>回填24h</button>
     </div>
+    <div id='window-buttons' style='display:flex;gap:4px'></div>
   </div>
   <h3 id='derivs-sym' style='margin:0'></h3>
   <div id='derivs-wrap' style='display:grid;grid-template-columns:1fr 1fr;gap:10px;align-items:start'></div>
@@ -77,6 +78,9 @@ let currentDepth=100;
 const depthButtons=document.getElementById('depth-buttons');
 const vaPercents=[0.7,0.75,0.8,0.85];
 let currentVA=0.7;
+const windowOptions=['5m','15m','30m','1h','4h','12h','24h'];
+let currentWindow='24h';
+const windowButtons=document.getElementById('window-buttons');
 let latestPrice=0;
 function updateOrdersTitle(){
   if(currentTab!=='orders') return;
@@ -131,6 +135,23 @@ function initVAButtons(){
     btns.appendChild(b);
   });
 }
+function initWindowButtons(){
+  if(windowButtons.hasChildNodes()) return;
+  windowOptions.forEach(w=>{
+    let b=document.createElement('button');
+    b.textContent=w.toUpperCase();
+    b.className='menu';
+    if(w===currentWindow) b.classList.add('active');
+    b.onclick=()=>{
+      currentWindow=w;
+      windowButtons.querySelectorAll('.menu').forEach(x=>x.classList.remove('active'));
+      b.classList.add('active');
+      document.getElementById('derivs-wrap').innerHTML='';
+      load();
+    };
+    windowButtons.appendChild(b);
+  });
+}
 async function showSym(sym,btn){
   currentSym=sym;
   symMenu.querySelectorAll('.menu').forEach(b=>b.classList.remove('active'));
@@ -157,6 +178,7 @@ function showTab(tab,btn){
   symMenu.style.display=needsSym?'flex':'none';
   if(needsSym) initSymMenu();
   if(tab==='orders') initDepthButtons();
+  if(tab==='derivs') initWindowButtons();
   if(tab==='settings') loadSettings();
   load();
 }
@@ -217,7 +239,7 @@ async function load(){
     if(!wrap.hasChildNodes()){
       ['price','funding','basis','oi'].forEach(kind=>{let box=document.createElement('div');box.id='derivs-'+kind;box.style.cssText='width:100%;height:260px;border:1px solid #ccc';wrap.appendChild(box);});
     }
-    let d=await fetch(`/chart/derivs?symbol=${currentSym}`).then(r=>r.json());
+    let d=await fetch(`/chart/derivs?symbol=${currentSym}&window=${currentWindow}`).then(r=>r.json());
     let x=toUTC8(d.timestamps);
     const toSeries = (arr, fn = v => v) =>
       (arr ?? []).map(v => {
@@ -250,7 +272,7 @@ async function load(){
       });
     };
     mk('derivs-price','Price (USD)',p,v=>'$'+Number(v).toFixed(dec),'#3BA272',true);
-    mk('derivs-funding','Funding (%)',f,v=>Number(v).toFixed(4)+'%','#5470C6');
+    mk('derivs-funding','Funding (%)',f,v=>Number(v).toFixed(4)+'%','#5470C6',true);
     mk('derivs-basis','Basis (USD)',b,v=>'$'+Number(v).toFixed(2),'#EE6666');
     mk('derivs-oi','Open Interest',o,v=>Math.round(v).toLocaleString(),'#91CC75',true);
   }else if(currentTab==='orders'){


### PR DESCRIPTION
## Summary
- Add selectable time windows (5M–24H) to derivatives tab
- Auto-scale funding and open interest charts

## Testing
- `python -m py_compile server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b96974411883298adfe34228a7689f