### PR TITLE
Ensure UTF-8 console output in run_server.bat

### DIFF
--- a/run_server.bat
+++ b/run_server.bat
@@ -1,5 +1,7 @@
 @echo off
 REM Ensure UTF-8 output and disable colored logs on Windows consoles
+chcp 65001 >nul
 set PYTHONUTF8=1
+set PYTHONIOENCODING=utf-8
 call mmenv\Scripts\activate
 uvicorn server:app --reload --host 0.0.0.0 --port 8001 --no-use-colors --log-config log_config.json


### PR DESCRIPTION
## Summary
- Set Windows console code page to 65001 before starting server
- Define PYTHONIOENCODING so logs use UTF-8

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba44325e7483299c5b64c533d9ee0f