### PR TITLE
记住挂单图表的缩放范围

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,8 @@ const windowOptions=['5m','15m','30m','1h','4h','12h','24h'];
 let currentWindow='24h';
 const windowButtons=document.getElementById('window-buttons');
 let latestPrice=0;
+let ordersChart=null;
+const ordersZoom={};
 function updateOrdersTitle(){
   if(currentTab!=='orders') return;
   const h=document.querySelector('#orders-wrap h3');
@@ -116,6 +118,7 @@ function initDepthButtons(){
       depthButtons.querySelectorAll('.menu').forEach(x=>x.classList.remove('active'));
       b.classList.add('active');
       document.getElementById('orders-wrap').innerHTML='';
+      ordersChart=null;
       load();
     };
     depthButtons.appendChild(b);
@@ -160,7 +163,7 @@ async function showSym(sym,btn){
   symMenu.querySelectorAll('.menu').forEach(b=>b.classList.remove('active'));
   if(btn) btn.classList.add('active');
   if(currentTab==='derivs') document.getElementById('derivs-wrap').innerHTML='';
-  if(currentTab==='orders') document.getElementById('orders-wrap').innerHTML='';
+  if(currentTab==='orders'){document.getElementById('orders-wrap').innerHTML='';ordersChart=null;}
   if(currentTab==='trades') document.getElementById('trades-wrap').innerHTML='';
   if(currentTab==='cancels') document.getElementById('cancels-wrap').innerHTML='';
   await refreshPrice();
@@ -295,7 +298,14 @@ async function load(){
       wrap.querySelector('h3').textContent=`${currentSym} Bids/Asks`;
     }
     let ob=await fetch(`/chart/orders?symbol=${currentSym}&limit=${currentDepth}`).then(r=>r.json());
-    let chart=echarts.init(document.getElementById('orders-chart'));
+    if(!ordersChart){
+      ordersChart=echarts.init(document.getElementById('orders-chart'));
+      ordersChart.on('dataZoom',()=>{
+        const dz=ordersChart.getOption().dataZoom?.[0];
+        if(dz) ordersZoom[currentSym]={startValue:dz.startValue,endValue:dz.endValue};
+      });
+    }
+    let chart=ordersChart;
     let dec=symDecimals[currentSym]??2;
 
     // Determine best bid/ask and mid price
@@ -335,8 +345,15 @@ async function load(){
     for(let i=fPrices.length-1;i>=0;i--){
       if(fPrices[i]<=upper){endIdx=i;break;}
     }
-    const startVal=axisVals[startIdx] ?? axisVals[0];
-    const endVal=axisVals[endIdx] ?? axisVals[axisVals.length-1];
+    let startVal,endVal;
+    const saved=ordersZoom[currentSym];
+    if(saved){
+      startVal=saved.startValue;
+      endVal=saved.endValue;
+    }else{
+      startVal=axisVals[startIdx] ?? axisVals[0];
+      endVal=axisVals[endIdx] ?? axisVals[axisVals.length-1];
+    }
 
     chart.setOption({
       tooltip:{},


### PR DESCRIPTION
## Summary
- Persist order book chart zoom via new `ordersChart` and `ordersZoom` globals and dataZoom listener.
- Reapply saved start/end values so refreshes honor user-selected price range.
- Reset chart state on depth or symbol changes to avoid stale instances.

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba4b5b2c248329a55bacc7236e94ea