### PR TITLE
Show two derivative charts per row

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     <div id='window-buttons' style='display:flex;gap:4px'></div>
   </div>
   <h3 id='derivs-sym' style='margin:0'></h3>
-  <div id='derivs-wrap' style='display:grid;grid-template-columns:1fr;gap:10px;align-items:start;width:100%'></div>
+  <div id='derivs-wrap' style='display:grid;grid-template-columns:repeat(2,1fr);gap:10px;align-items:start;width:100%'></div>
   <div id='backfill-note' style='color:#888;font-size:12px;margin-top:4px'></div>
 </div>
 <div id='tab-orders' style='display:none'>


### PR DESCRIPTION
## Summary
- display two derivative charts per row by using a two-column grid in the derivatives tab

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: ex_dict.py invalid syntax)*
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py' | grep -v 'ex_dict')`


------
https://chatgpt.com/codex/tasks/task_b_68ba95b118f083298c3240231bd04660