### PR TITLE
feat: add liquidation map from major exchanges

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <button class='menu top' onclick="showTab('orders',this)">挂单</button>
   <button class='menu top' onclick="showTab('trades',this)">成交</button>
   <button class='menu top' onclick="showTab('cancels',this)">取消</button>
+  <button class='menu top' onclick="showTab('liqs',this)">清算</button>
   <button class='menu top' onclick="showTab('settings',this)">设置</button>
 </div>
 <div id='sym-menu' style='display:none;gap:8px;flex-wrap:wrap;margin-top:8px'></div>
@@ -49,6 +50,9 @@
 </div>
 <div id='tab-cancels' style='display:none'>
   <div id='cancels-wrap' style='margin-top:10px;width:100%'></div>
+</div>
+<div id='tab-liqs' style='display:none'>
+  <div id='liqs-wrap' style='margin-top:10px;width:100%'></div>
 </div>
 <div id='tab-settings' style='display:none'>
   <h3>系统设置</h3>
@@ -85,6 +89,7 @@ const windowButtons=document.getElementById('window-buttons');
 let latestPrice=0;
 let ordersChart=null;
 const ordersZoom={};
+let lastLiqFetch=0;
 function updateOrdersTitle(){
   if(currentTab!=='orders') return;
   const h=document.querySelector('#orders-wrap h3');
@@ -195,6 +200,7 @@ async function showSym(sym,btn){
   if(currentTab==='orders'){document.getElementById('orders-wrap').innerHTML='';ordersChart=null;}
   if(currentTab==='trades') document.getElementById('trades-wrap').innerHTML='';
   if(currentTab==='cancels') document.getElementById('cancels-wrap').innerHTML='';
+  if(currentTab==='liqs'){document.getElementById('liqs-wrap').innerHTML='';lastLiqFetch=0;}
   await refreshPrice();
   load();
 }
@@ -206,15 +212,17 @@ function showTab(tab,btn){
   document.getElementById('tab-orders').style.display=(tab==='orders')?'block':'none';
   document.getElementById('tab-trades').style.display=(tab==='trades')?'block':'none';
   document.getElementById('tab-cancels').style.display=(tab==='cancels')?'block':'none';
+  document.getElementById('tab-liqs').style.display=(tab==='liqs')?'block':'none';
   document.getElementById('tab-settings').style.display=(tab==='settings')?'block':'none';
   document.querySelectorAll('.menu.top').forEach(b=>b.classList.remove('active'));
   if(btn) btn.classList.add('active');
-  const needsSym=['derivs','orders','trades','cancels'].includes(tab);
+  const needsSym=['derivs','orders','trades','cancels','liqs'].includes(tab);
   symMenu.style.display=needsSym?'flex':'none';
   if(needsSym) initSymMenu();
   if(tab==='orders') initDepthButtons();
   if(tab==='derivs') initWindowButtons();
   if(tab==='settings') loadSettings();
+  if(tab==='liqs') lastLiqFetch=0;
   load();
 }
 async function loadSettings(){
@@ -484,8 +492,22 @@ async function load(){
     }else{
       tc.clear();
     }
+  }else if(currentTab==='liqs'){
+      let wrap=document.getElementById('liqs-wrap');
+      if(!wrap.hasChildNodes()){
+        wrap.innerHTML=`<h3>${displaySym(currentSym)}</h3><div id='liqs-chart' style='width:100%;height:80vh;border:1px solid #ccc'></div>`;
+      }else{
+        wrap.querySelector('h3').textContent=displaySym(currentSym);
+      }
+      const now=Date.now();
+      if(now-lastLiqFetch<60000) return;
+      lastLiqFetch=now;
+      let d=await fetch(`/chart/liquidations?symbol=${currentSym}`).then(r=>r.json());
+      let prices=d.prices.map(p=>p.toString());
+      let chart=echarts.init(document.getElementById('liqs-chart'));
+      chart.setOption({tooltip:{},xAxis:{type:'category',data:prices},yAxis:{type:'value'},series:[{type:'bar',data:d.volumes}]});
   }else if(currentTab==='cancels'){
-    let wrap=document.getElementById('cancels-wrap');
+      let wrap=document.getElementById('cancels-wrap');
     if(!wrap.hasChildNodes()){
       wrap.innerHTML=`<h3>${displaySym(currentSym)}</h3><div id='cancels-line' style='width:800px;height:320px;border:1px solid #ccc;margin-top:10px'></div>`;
     }else{

--- a/liquidations.py
+++ b/liquidations.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Fetch recent liquidation events from major exchanges and aggregate them.
+
+This module queries public REST endpoints of Binance, OKX and Bybit to obtain
+recent liquidation orders.  Results are normalised to a common structure and
+can be aggregated into price bins suitable for visualising a liquidation map.
+
+Only a very small subset of the exchanges' capabilities is used here – the
+intent is to provide lightweight data for the front‑end heatmap.  Endpoints are
+queried without authentication except for Binance which requires an API key.
+The key should be supplied via the ``BINANCE_API_KEY`` environment variable and
+no secret is needed because the liquidation endpoint does not require request
+signing.
+"""
+
+import os
+import time
+import asyncio
+from collections import defaultdict
+from typing import Any, Dict, List
+
+import httpx
+
+
+async def _binance(symbol: str) -> List[Dict[str, Any]]:
+    """Return recent liquidation orders from Binance futures."""
+    url = "https://fapi.binance.com/fapi/v1/liquidationOrders"
+    params = {"symbol": symbol, "limit": 1000}
+    headers = {}
+    api_key = os.getenv("BINANCE_API_KEY")
+    if api_key:
+        headers["X-MBX-APIKEY"] = api_key
+    try:
+        async with httpx.AsyncClient(timeout=10, headers=headers) as client:
+            resp = await client.get(url, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            return [
+                {
+                    "price": float(it.get("price", 0)),
+                    "qty": float(it.get("origQty", 0)),
+                    "side": it.get("side", ""),
+                    "ts": int(it.get("time", 0)),
+                }
+                for it in data
+            ]
+    except Exception:
+        return []
+
+
+async def _okx(symbol: str) -> List[Dict[str, Any]]:
+    """Return recent liquidation orders from OKX swaps."""
+    inst = symbol.replace("USDT", "-USDT")
+    url = "https://www.okx.com/api/v5/public/liq-order"
+    params = {"instType": "SWAP", "instId": f"{inst}-SWAP"}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, params=params)
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+            return [
+                {
+                    "price": float(it.get("fillPx", 0)),
+                    "qty": float(it.get("fillSz", 0)),
+                    "side": it.get("side", ""),
+                    "ts": int(float(it.get("ts", 0))),
+                }
+                for it in data
+            ]
+    except Exception:
+        return []
+
+
+async def _bybit(symbol: str) -> List[Dict[str, Any]]:
+    """Return recent liquidation orders from Bybit linear swaps."""
+    url = "https://api.bybit.com/v5/market/liquidation"
+    params = {"category": "linear", "symbol": symbol}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, params=params)
+            resp.raise_for_status()
+            data = resp.json().get("result", {}).get("list", [])
+            return [
+                {
+                    "price": float(it.get("price", 0)),
+                    "qty": float(it.get("qty", 0)),
+                    "side": it.get("side", ""),
+                    "ts": int(it.get("createdTime", 0)),
+                }
+                for it in data
+            ]
+    except Exception:
+        return []
+
+
+async def fetch_map(symbol: str, bin_size: float = 100.0) -> Dict[str, Any]:
+    """Fetch liquidation data from all exchanges and aggregate into price bins."""
+    binance, okx, bybit = await asyncio.gather(
+        _binance(symbol), _okx(symbol), _bybit(symbol)
+    )
+    events = [("binance", e) for e in binance] + [("okx", e) for e in okx] + [
+        ("bybit", e) for e in bybit
+    ]
+    bins: Dict[int, float] = defaultdict(float)
+    for _, ev in events:
+        price = float(ev.get("price", 0))
+        qty = abs(float(ev.get("qty", 0)))
+        if price <= 0 or qty <= 0:
+            continue
+        b = int(price // bin_size * bin_size)
+        bins[b] += qty
+    prices = sorted(bins.keys())
+    volumes = [bins[p] for p in prices]
+    return {"prices": prices, "volumes": volumes, "bin_size": bin_size, "ts": int(time.time())}

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover - dependency may be missing
 from derivatives import append_history as append_deriv_history
 from derivatives import fetch_all as fetch_derivs
 from derivatives import backfill as derivs_backfill
+from liquidations import fetch_map as fetch_liq_map
 from db import (
     init_db,
     save_derivs as db_save_derivs,
@@ -896,6 +897,18 @@ async def chart_trades(symbol: str) -> Dict[str, Any]:
     price = await fetch_price(sym)
 
     return {"symbol": sym, "prices": prices, "volumes": volumes, "price": price}
+
+
+@app.get("/chart/liquidations")
+async def chart_liquidations(symbol: str) -> Dict[str, Any]:
+    """Return aggregated liquidation map for ``symbol`` across exchanges."""
+
+    sym = symbol.upper()
+    try:
+        data = await fetch_liq_map(sym)
+    except Exception:
+        data = {"prices": [], "volumes": [], "bin_size": 100.0, "ts": int(time.time())}
+    return {"symbol": sym, **data}
 
 
 @app.post("/labels/import")


### PR DESCRIPTION
## Summary
- add "清算" tab with minute-level refresh
- pull and aggregate liquidation orders from Binance, OKX and Bybit
- expose `/chart/liquidations` endpoint for front-end heatmap

## Testing
- `python -m py_compile server.py liquidations.py`


------
https://chatgpt.com/codex/tasks/task_b_68baa06f240883299ea7c7d0e662e0b6