### PR TITLE
Remove 10% price limit in order book view

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@ async function load(){
     const threshold=currentFilter;
     for(let i=0;i<prices.length;i++){
       const p=prices[i];
-      if(Math.abs(p-refPrice)/refPrice>0.1) continue;
+      // Show full depth without restricting to ±10% around the reference price
       fPrices.push(p);
       const bq=buys[i];
       const sq=sells[i];


### PR DESCRIPTION
## Summary
- show full order book depth by removing ±10% price filter

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bab33815688329a0a2182a0ad6c91b