### PR TITLE
fix: use authenticated Binance liquidation endpoint

### DIFF
--- a/liquidations.py
+++ b/liquidations.py
@@ -2,48 +2,79 @@ from __future__ import annotations
 
 """Fetch recent liquidation events from major exchanges and aggregate them.
 
-This module queries public REST endpoints of Binance, OKX and Bybit to obtain
-recent liquidation orders.  Results are normalised to a common structure and
-can be aggregated into price bins suitable for visualising a liquidation map.
+This module queries REST endpoints of Binance, OKX and Bybit to obtain recent
+liquidation orders.  Results are normalised to a common structure and can be
+aggregated into price bins suitable for visualising a liquidation map.
 
 Only a very small subset of the exchanges' capabilities is used here – the
-intent is to provide lightweight data for the front‑end heatmap.  Endpoints are
-queried without authentication except for Binance which requires an API key.
-The key should be supplied via the ``BINANCE_API_KEY`` environment variable and
-no secret is needed because the liquidation endpoint does not require request
-signing.
+intent is to provide lightweight data for the front‑end heatmap.  Binance's
+endpoint requires API credentials and request signing.  API key and secret are
+loaded from ``settings.json`` (falling back to the ``BINANCE_API_KEY`` and
+``BINANCE_API_SECRET`` environment variables).
 """
 
 import os
 import time
+import json
+import hmac
+import hashlib
 import asyncio
+from pathlib import Path
 from collections import defaultdict
 from typing import Any, Dict, List
 
 import httpx
 
 
+def _binance_keys() -> tuple[str, str]:
+    """Return API key and secret for Binance from settings or environment."""
+
+    cfg = {}
+    p = Path(__file__).resolve().parent / "settings.json"
+    if p.exists():
+        try:
+            cfg = json.loads(p.read_text())
+        except Exception:
+            cfg = {}
+    binance = cfg.get("exchanges", {}).get("binance", {})
+    key = binance.get("api_key") or os.getenv("BINANCE_API_KEY", "")
+    secret = binance.get("secret") or os.getenv("BINANCE_API_SECRET", "")
+    return key, secret
+
+
 async def _binance(symbol: str) -> List[Dict[str, Any]]:
-    """Return recent liquidation orders from Binance futures."""
+    """Return outstanding liquidation orders from Binance futures."""
+
+    key, secret = _binance_keys()
+    if not key or not secret:
+        return []
+
     url = "https://fapi.binance.com/fapi/v1/liquidationOrders"
-    params = {"symbol": symbol, "limit": 1000}
-    headers = {}
-    api_key = os.getenv("BINANCE_API_KEY")
-    if api_key:
-        headers["X-MBX-APIKEY"] = api_key
+    params = {
+        "symbol": symbol,
+        "limit": 1000,
+        "timestamp": int(time.time() * 1000),
+    }
+    query = "&".join(f"{k}={params[k]}" for k in params)
+    signature = hmac.new(secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+    headers = {"X-MBX-APIKEY": key}
     try:
-        async with httpx.AsyncClient(timeout=10, headers=headers) as client:
-            resp = await client.get(url, params=params)
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, params={**params, "signature": signature}, headers=headers)
             resp.raise_for_status()
             data = resp.json()
             return [
                 {
                     "price": float(it.get("price", 0)),
-                    "qty": float(it.get("origQty", 0)),
+                    "qty": max(
+                        float(it.get("origQty", 0)) - float(it.get("executedQty", 0)),
+                        0.0,
+                    ),
                     "side": it.get("side", ""),
                     "ts": int(it.get("time", 0)),
                 }
                 for it in data
+                if it.get("status") != "FILLED"
             ]
     except Exception:
         return []

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,9 @@
+{
+  "exchanges": {
+    "binance": {
+      "api_key": "F4bZyVxQ3KoUD5d5eP3b19WhyHtTzce7TgpsUDHsiATrnTn0sxWZayGIHhI5j9oJ",
+      "secret": "UjLP82tT5S3w0AZKKjTm7hhK1i4O0Ivj5hqJRyPfQsT9TKVvZf8xTG0UQl1ha1EH",
+      "api_base": "https://api.binance.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- load Binance API credentials from settings and sign requests
- query Binance `liquidationOrders` to return outstanding liquidation amounts
- add settings with provided Binance key and secret

## Testing
- `python -m py_compile liquidations.py`


------
https://chatgpt.com/codex/tasks/task_b_68bab26bf8248329afcf088f08029c36